### PR TITLE
Never throw an exception on kill 0, $pid if called in non-void context

### DIFF
--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 use Tie::RefHash;   # To cache subroutine refs
 use Config;
-use Scalar::Util qw(set_prototype);
+use Scalar::Util qw(set_prototype looks_like_number);
 
 use autodie::Util qw(
   fill_protos
@@ -1037,9 +1037,10 @@ sub _one_invocation {
             my \$context = ! defined wantarray() ? 'void' : 'scalar';
             my \$signal = \$_[0];
             my \$retval = $call(@argv);
+            my \$sigzero = looks_like_number( \$signal ) and \$signal == 0;
 
-            if ( (\$signal == 0 and \$context eq 'void')
-                 or (\$signal != 0 and \$retval != \$num_things) ) {
+            if (    (   \$sigzero and \$context eq 'void' )
+                 or ( ! \$sigzero and \$retval != \$num_things ) ) {
 
                 $die;
             }

--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -1029,6 +1029,25 @@ sub _one_invocation {
         };
     }
 
+    if ($call eq 'CORE::kill') {
+
+        return qq[
+
+            my \$num_things = \@_ - $Returns_num_things_changed{$call};
+            my \$context = ! defined wantarray() ? 'void' : 'scalar';
+            my \$signal = \$_[0];
+            my \$retval = $call(@argv);
+
+            if ( (\$signal == 0 and \$context eq 'void')
+                 or (\$signal != 0 and \$retval != \$num_things) ) {
+
+                $die;
+            }
+
+            return \$retval;
+        ];
+    }
+
     if (exists $Returns_num_things_changed{$call}) {
 
         # Some things return the number of things changed (like

--- a/t/kill.t
+++ b/t/kill.t
@@ -13,14 +13,22 @@ if (CORE::kill(0, SYSINIT)) {
     plan skip_all => "Can unexpectedly signal process 1. Won't run as root.";
 }
 
-plan tests => 4;
+$SIG{HUP} = sub { }; # Ignore SIGHUP
 
-eval { kill(0, $$); };
+plan tests => 6;
+
+eval { my $rv = kill(0, $$); };
 is($@, '', "Signalling self is fine");
 
-eval { kill(0, SYSINIT ) };
-isa_ok($@, 'autodie::exception', "Signalling init is not allowed.");
+eval { kill(1, $$); };
+is($@, '', "Kill with non-zero signal, in void context is ok");
 
-eval { kill(0, $$, SYSINIT) };
+eval { kill(0, SYSINIT) };
+isa_ok($@, 'autodie::exception', "kill 0 should die if called in void context");
+
+eval { my $rv = kill(0, SYSINIT) };
+is($@, '', "kill 0 should never die if called in scalar context");
+
+eval { my $rv = kill(1, $$, SYSINIT) };
 isa_ok($@, 'autodie::exception', 'kill exception on single failure.');
 is($@->return, 1, "kill fails correctly on a 'true' failure.");

--- a/t/kill.t
+++ b/t/kill.t
@@ -20,7 +20,7 @@ plan tests => 6;
 eval { my $rv = kill(0, $$); };
 is($@, '', "Signalling self is fine");
 
-eval { kill(1, $$); };
+eval { kill('HUP', $$); };
 is($@, '', "Kill with non-zero signal, in void context is ok");
 
 eval { kill(0, SYSINIT) };
@@ -29,6 +29,6 @@ isa_ok($@, 'autodie::exception', "kill 0 should die if called in void context");
 eval { my $rv = kill(0, SYSINIT) };
 is($@, '', "kill 0 should never die if called in scalar context");
 
-eval { my $rv = kill(1, $$, SYSINIT) };
+eval { my $rv = kill('HUP', $$, SYSINIT) };
 isa_ok($@, 'autodie::exception', 'kill exception on single failure.');
 is($@->return, 1, "kill fails correctly on a 'true' failure.");


### PR DESCRIPTION
If the called in list or scalar context, will no longer throw an
exception when kill(0,$pid) returns a zero value (or a value less the
number of pids supplied). Always dies if kill(0,$pid) is called in void
context.
